### PR TITLE
Add special textures for Synth Bass 1 and Synth Bass 2

### DIFF
--- a/implementation.adoc
+++ b/implementation.adoc
@@ -31,8 +31,8 @@ Check this page to see the progress of each instrument's implementation.
 |_36_ Fretless Bass image:doc/brush.png[]|_44_ Contrabass image:doc/check.png[]|_52_ Synth Strings 2 image:doc/brush.png[]|_60_ Muted Trumpet image:doc/check.png[]
 |_37_ Slap Bass 1 image:doc/check.png[]|_45_ Tremolo Strings image:doc/brush.png[]|_53_ Choir Aahs image:doc/check.png[]|_61_ French Horn image:doc/check.png[]
 |_38_ Slap Bass 2 image:doc/check.png[]|_46_ Pizzicato Strings image:doc/check.png[]|_54_ Voice Oohs image:doc/brush.png[]|_62_ Brass Section image:doc/check.png[]
-|_39_ Synth Bass 1 image:doc/check.png[]|_47_ Orchestral Harp image:doc/check.png[]|_55_ Synth Voice image:doc/brush.png[]|_63_ Synth Brass 1 image:doc/check.png[]
-|_40_ Synth Bass 2 image:doc/check.png[]|_48_ Timpani image:doc/check.png[]|_56_ Orchestra Hit image:doc/check.png[]|_64_ Synth Brass 2 image:doc/check.png[]
+|_39_ Synth Bass 1 image:doc/check.png[]|_47_ Orchestral Harp image:doc/check.png[]|_55_ Synth Voice image:doc/brush.png[]|_63_ Synth Brass 1 image:doc/brush.png[]
+|_40_ Synth Bass 2 image:doc/check.png[]|_48_ Timpani image:doc/check.png[]|_56_ Orchestra Hit image:doc/check.png[]|_64_ Synth Brass 2 image:doc/brush.png[]
 |===
 
 |===
@@ -56,7 +56,7 @@ Check this page to see the progress of each instrument's implementation.
 |_101_ FX 5 (brightness) image:doc/check.png[]|_109_ Kalimba image:doc/cross.png[]|_117_ Taiko Drum image:doc/check.png[]|_125_ Telephone Ring image:doc/check.png[]
 |_102_ FX 6 (goblins) image:doc/check.png[]|_110_ Bag pipe image:doc/cross.png[]|_118_ Melodic Tom image:doc/check.png[]|_126_ Helicopter image:doc/plus.png[]
 |_103_ FX 7 (echoes) image:doc/check.png[]|_111_ Fiddle image:doc/brush.png[]|_119_ Synth Drum image:doc/check.png[]|_127_ Applause image:doc/check.png[]
-|_104_ FX 8 (sci-fi) image:doc/check.png[]|_112_ Shanai image:doc/cross.png[]|_120_ Reverse Cymbal image:doc/cross.png[]|_128_ Gunshot image:doc/cross.png[]
+|_104_ FX 8 (sci-fi) image:doc/check.png[]|_112_ Shanai image:doc/cross.png[]|_120_ Reverse Cymbal image:doc/plus.png[]|_128_ Gunshot image:doc/cross.png[]
 |===
 
 == Percussion instruments


### PR DESCRIPTION
i was hoping that you will add special textures for Synth Bass 1 and Synth Bass 2. i promise.
![SynthBass2Skin](https://user-images.githubusercontent.com/94708960/142674523-ec86c44a-a562-4397-be6c-0b7dfd24b90b.png)
![SynthBass1Skin](https://user-images.githubusercontent.com/94708960/142674545-ac004b51-0054-42af-baed-2d6cc1764860.png)

