### PR TITLE
Fix crash when first tempo event is at non-zero time

### DIFF
--- a/src/main/kotlin/org/wysko/midis2jam2/midi/MidiFile.kt
+++ b/src/main/kotlin/org/wysko/midis2jam2/midi/MidiFile.kt
@@ -42,8 +42,14 @@ abstract class MidiFile(
      * tick, and duplicates have been removed (if multiple events have the same tick, the last one is kept).
      */
     val tempos: List<MidiTempoEvent> by lazy {
-        tracks.flatMap { it.events }.filterIsInstance<MidiTempoEvent>().ifEmpty { listOf(MidiTempoEvent(0, 500_000)) }
-            .sortedBy { it.time }.asReversed().distinctBy { it.time }.asReversed()
+        tracks.flatMap { it.events }.filterIsInstance<MidiTempoEvent>()
+            .ifEmpty { listOf(MidiTempoEvent(0, ONE_HUNDRED_TWENTY_BPM)) }
+            .sortedBy { it.time }.asReversed().distinctBy { it.time }.asReversed().toMutableList().also {
+                // If the first tempo event doesn't occur at the beginning of the MIDI file, assume 120 BPM.
+                if (it.first().time != 0L) {
+                    it.add(0, MidiTempoEvent(0, ONE_HUNDRED_TWENTY_BPM))
+                }
+            }.toList()
     }
 
     /** Maps MIDI events to their occurrence time in seconds. */

--- a/src/main/kotlin/org/wysko/midis2jam2/midi/MidiTempoEvent.kt
+++ b/src/main/kotlin/org/wysko/midis2jam2/midi/MidiTempoEvent.kt
@@ -17,6 +17,11 @@
 package org.wysko.midis2jam2.midi
 
 /**
+ * The number of microseconds in a beat when the BPM is 120.
+ */
+const val ONE_HUNDRED_TWENTY_BPM: Int = 500_000
+
+/**
  * Defines how fast the MIDI file should play.
  *
  * @param time   the time


### PR DESCRIPTION
Fix the issue where an exception is thrown if the first tempo event in a MIDI file does not occur at time zero.

Per the SMF specification, the tempo shall be assumed to be 120 BPM. The easiest fix to this is just to add a tempo event of 120 BPM at time zero if no tempo event occurs then.

Fixes #160