### PR TITLE
Fix MIDI reset option can't to set to none (#329)

### DIFF
--- a/app/src/desktopMain/kotlin/org/wysko/midis2jam2/ui/settings/SettingsScreen.desktop.kt
+++ b/app/src/desktopMain/kotlin/org/wysko/midis2jam2/ui/settings/SettingsScreen.desktop.kt
@@ -389,7 +389,10 @@ private fun SpecificationResetSelect(settings: State<AppSettings>, model: Settin
     }
 
     SelectRow(
-        option = settings.value.playbackSettings.midiSpecificationResetSettings.midiSpecification,
+        option = when (settings.value.playbackSettings.midiSpecificationResetSettings.isSendSpecificationResetMessage) {
+            true -> settings.value.playbackSettings.midiSpecificationResetSettings.midiSpecification
+            false -> null
+        },
         onOptionSelected = {
             if (it == null) {
                 model.setIsSendResetMessage(false)


### PR DESCRIPTION
Fix the issue where the MIDI specification reset message option was not able to be set to "None"

Fixes #329