### PR TITLE
Add support for "XF Style" Lyrics

### DIFF
--- a/app/src/commonMain/kotlin/org/wysko/midis2jam2/world/lyric/LyricController.kt
+++ b/app/src/commonMain/kotlin/org/wysko/midis2jam2/world/lyric/LyricController.kt
@@ -182,7 +182,7 @@ class LyricController(private val context: Midis2jam2, private val events: List<
 
 private val separators = listOf("\n", "\r", "\r\n")
 
-private fun String.display() = clean().replace("/", "").replace("\\", "").replace(">", "").replace("<", "").replace("^", " ")
+private fun String.display() = clean().replace("/", "").replace("\\", "").removePrefix("<").replace("^", " ")
 
 private fun String.clean() = when {
     this.trim().startsWith("\"") && this.trim().endsWith("\"") -> this.trim().removeSurrounding("\"")
@@ -202,7 +202,7 @@ private fun List<MetaEvent.Lyric>.partitionByNewLines(): List<LyricLine> {
                 line = mutableListOf()
             }
 
-            item.text.clean().startsWith("/") || item.text.clean().startsWith("\\") -> {
+            item.text.clean().startsWith("/") || item.text.clean().startsWith("\\") || item.text.clean().startsWith("<") -> {
                 if (line.isNotEmpty()) result.add(line)
                 line = mutableListOf()
                 line.add(item)


### PR DESCRIPTION
This PR adds support for "XF Style" (*not "XF Format"*) lyrics, where `^` is a space and `/` is a new line.

<img width="738" height="73" alt="image" src="https://github.com/user-attachments/assets/78682550-cd12-443a-a8ae-092e7904b320" />

<img width="157" height="133" alt="image" src="https://github.com/user-attachments/assets/695d82d5-e208-45a7-994d-eb0fe5e6cdc2" />

MIDI Download: [12DaysXmas.zip](https://github.com/user-attachments/files/23697735/12DaysXmas.zip)
